### PR TITLE
Default to the first display if there are no primaries detected.

### DIFF
--- a/d3dshot/d3dshot.py
+++ b/d3dshot/d3dshot.py
@@ -23,7 +23,8 @@ class D3DShot:
         self.displays = None
         self.detect_displays()
 
-        self.display = None
+        # default to the first display in case there are no primaries
+        self.display = self.displays[0] if len(self.displays) > 0 else None 
 
         for display in self.displays:
             if display.is_primary:


### PR DESCRIPTION
In response to Issue #5 