### PR TITLE
Bump pillow version (fixes #44)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ include = []
 python = ">=3.6"
 
 comtypes = "~1.1.7"
-pillow = "~7.1.2"
+pillow = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]
 ipython = "~7.14"


### PR DESCRIPTION
This fixes issue #44. Changed pillow requirements to at least version 7.1.2.